### PR TITLE
Replace ends_with repetition with i8 modulo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/ordinal"
 readme = "README.md"
 
 [dependencies]
-num-integer = "0.1"
+num-integer = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 num-bigint = "0.4.3"


### PR DESCRIPTION
This pull request improves the logic of the suffix function to avoid repeated `ends_with` calls.

I tried other ways of going about this (with the intention of avoiding the to_string conversion and allocation) but I arrived at this because it maintains the most compatibility, especially when used with types like BigInt from the num crate, etc.

The new logic works like this:

1. Convert the number to a string
2. Get the last two characters of the string
3. Convert the last two characters into an i8
4. Make the i8 positive so it can only be between 0 and 99
5. Modulo the i8 and match based on English ordinal rules